### PR TITLE
example of alternate approach to theming, using a global class

### DIFF
--- a/src/app/root/index.jsx
+++ b/src/app/root/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import queryString from 'query-string';
-import { ThemeProvider } from 'react-css-themr';
+
 import Page from '../../components/page';
 import Body from '../../components/page/body';
 import Button from '../../components/button';
@@ -27,12 +27,12 @@ class Root extends React.Component {
   render() {
     const { location } = this.props;
     const query = queryString.parse(location.search);
-    const theme = themes[query.theme || 'light'];
+    const theme = query.theme || 'light';
 
     return (
-      <ThemeProvider theme={theme}>
+      <div className={`theme-${theme}`}>
         {this.renderContent()}
-      </ThemeProvider>
+      </div>
     );
   }
 }

--- a/src/components/page/body/index.jsx
+++ b/src/components/page/body/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cn from 'classnames';
-import { themr } from 'react-css-themr';
+import styles from "./styles/body.css";
 
 function Body(props) {
   return (
-    <div className={cn(props.theme.body, props.className)}>
+    <div className={cn(styles.body, props.className)}>
       {props.children}
     </div>
   );
@@ -24,4 +24,4 @@ if (__DEV__) {
   };
 }
 
-export default themr('body')(Body);
+export default Body;

--- a/src/components/page/body/styles/body.css
+++ b/src/components/page/body/styles/body.css
@@ -4,3 +4,7 @@
   padding: 40px;
   flex: 1;
 }
+
+:global(.theme-dark) .body {
+  background-color: rgba(36,52,68,1)
+}


### PR DESCRIPTION
This is an example of a different approach, to weigh up pros / cons.

I haven't applied it everywhere, just in a couple of places so you can see what's changed.

The basic idea is:

- apply a global class to an outer element (eg. `theme-dark`)
- rather than creating a separate stylesheet for every theme, just define the default theme and then override with theme rules where necessary. Eg.

```css
.body {
  /* default styles */
}

global(.theme-dark) .body {
  /* theme override */
}
```

While it uses global classes and cascading, which are sort of against the spirit of css modules, if we use them in a restrained way it will work fine.  There's also less magic to it than `react-css-themr` so it might be easier to maintain.